### PR TITLE
Feature: Add Sprint model schema

### DIFF
--- a/src/models/Sprint.js
+++ b/src/models/Sprint.js
@@ -1,0 +1,39 @@
+import mongoose from "mongoose";
+
+const sprintSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true,
+    trim: true,
+  },
+  startDate: {
+    type: Date,
+    required: true,
+  },
+  endDate: {
+    type: Date,
+    required: true,
+  },
+  goal: {
+    type: String,
+    required: true,
+  },
+  status: {
+    type: String,
+    enum: ["planned", "in_progress", "finished"],
+    default: "planned",
+  },
+  idealVelocity: {
+    type: Number,
+    default: 0,
+  },
+  realVelocity: {
+    type: Number,
+    default: 0,
+  },
+  observations: {
+    type: String,
+  },
+}, { timestamps: true });
+
+export default mongoose.model("Sprint", sprintSchema);


### PR DESCRIPTION
Este PR añade el modelo Sprint para definir cómo se estructuran y almacenan los datos de los sprints en MongoDB.

### Detalle
- Creado el archivo `src/models/Sprint.js`
- Definido el esquema de Mongoose con los campos:
  - name
  - startDate
  - endDate
  - goal
  - status
  - idealVelocity
  - realVelocity
  - observations
- Habilitados los timestamps automáticos (`createdAt` y `updatedAt`)

### ¿Por qué?
El modelo Sprint es esencial para gestionar los sprints en el backend y servirá como base para los futuros controladores y rutas del módulo de Sprints.

### Notas
- Revisar consistencia de nombres de campos con las convenciones del proyecto
- Revisar si se necesitan validaciones adicionales